### PR TITLE
Changing API to encompas multiple output bits.

### DIFF
--- a/QRam.sln
+++ b/QRam.sln
@@ -1,0 +1,67 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "qram", "src\qram.csproj", "{DDD89D88-1484-4D86-B18C-F9267AB73C74}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "tests", "tests\tests.csproj", "{F0398818-74CB-4B47-981B-39CA7B214E5A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{BC9A489D-88AF-4DE2-A3EE-F31A1FE47D7A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "implicitQRAM", "samples\implicitQRAM\implicitQRAM.csproj", "{7DAD2361-E333-4076-B840-FACA90D354F7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Debug|x64.Build.0 = Debug|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Debug|x86.Build.0 = Debug|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Release|x64.ActiveCfg = Release|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Release|x64.Build.0 = Release|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Release|x86.ActiveCfg = Release|Any CPU
+		{DDD89D88-1484-4D86-B18C-F9267AB73C74}.Release|x86.Build.0 = Release|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Debug|x64.Build.0 = Debug|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Debug|x86.Build.0 = Debug|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Release|x64.ActiveCfg = Release|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Release|x64.Build.0 = Release|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Release|x86.ActiveCfg = Release|Any CPU
+		{F0398818-74CB-4B47-981B-39CA7B214E5A}.Release|x86.Build.0 = Release|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Debug|x64.Build.0 = Debug|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Debug|x86.Build.0 = Debug|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Release|x64.ActiveCfg = Release|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Release|x64.Build.0 = Release|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Release|x86.ActiveCfg = Release|Any CPU
+		{7DAD2361-E333-4076-B840-FACA90D354F7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{7DAD2361-E333-4076-B840-FACA90D354F7} = {BC9A489D-88AF-4DE2-A3EE-F31A1FE47D7A}
+	EndGlobalSection
+EndGlobal

--- a/samples/implicitQRAM/Program.qs
+++ b/samples/implicitQRAM/Program.qs
@@ -2,6 +2,7 @@
 
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Measurement;
     open Qram;
@@ -41,12 +42,12 @@
 //        }
 //    }
 
-    //Generates binary representation of [5,4,1]
-    function GenerateMemoryData() : Bool[][] {
-        let five = [true,false,true];
-        let four = [false,false,true];
-        let one = [false,false,true];
-        return [five, four, one];
+    //Generates binary representation of [5,4,1]=>[3,2,1]
+    function GenerateMemoryData() : (Bool[],Bool[])[] {
+        let fiveGivesThree = (IntAsBoolArray(5,3),IntAsBoolArray(3,2));
+        let fourGivesTwo = (IntAsBoolArray(4,3),IntAsBoolArray(2,2));
+        let oneGivesOne = (IntAsBoolArray(1,3),IntAsBoolArray(1,2));
+        return [fiveGivesThree, fourGivesTwo, oneGivesOne];
     }
 }
 

--- a/src/Library.qs
+++ b/src/Library.qs
@@ -24,7 +24,7 @@
     function ImplicitQRAMOracle(DataValues : (Bool[],Bool[])[]) : QRAM {
         mutable addressSize = 0;
         mutable valueSize = 0;
-        for((_,(address,value)) in Enumerated(DataValues)){
+        for ((address, value)  in DataValues){
             if(Length(address) > addressSize){
                 set addressSize = Length(address);
             }
@@ -40,8 +40,7 @@
             w/ DataSize <- valueSize;
     }
     
-    internal function SingleImplicitQRAMOracle(DataValue : (Bool[],Bool[])) : SingleBitQRAM {
-        let (address,value) = DataValue;
+    internal function SingleImplicitQRAMOracle(address : Bool[], value : Bool[]) : SingleBitQRAM {
         return Default<SingleBitQRAM>()
             w/ Lookup <- ApplySingleImplicitQRAMOracleValues(address, value, _, _);
     }

--- a/src/Library.qs
+++ b/src/Library.qs
@@ -19,16 +19,46 @@
         DataSize : Int);
 
     //Internal QRam type for a single QRAM Bit (is composed to form a full memory block)
-    internal newtype SingleBitQRAM = (Lookup : ((Qubit[], Qubit) => Unit is Adj + Ctl), 
-        AddressSize : Int);
+    internal newtype SingleBitQRAM = (Lookup : ((Qubit[], Qubit[]) => Unit is Adj + Ctl));
 
-    function ImplicitQRAMOracle(dataValues : Bool[][]) : QRAM {
-        let onesAddresses = OnesAddressesFromData(dataValues);
-        let qrams = Mapped(SingleImplicitQRAMOracle, onesAddresses); 
+    function ImplicitQRAMOracle(DataValues : (Bool[],Bool[])[]) : QRAM {
+        mutable addressSize = 0;
+        mutable valueSize = 0;
+        for((_,(address,value)) in Enumerated(DataValues)){
+            if(Length(address) > addressSize){
+                set addressSize = Length(address);
+            }
+            if(Length(value) > valueSize){
+                set valueSize = Length(value);
+            }
+        }
+
+        let qrams = Mapped(SingleImplicitQRAMOracle, DataValues); 
         return Default<QRAM>()
             w/ Lookup <- ApplyImplicitQRAMOracle(qrams, _, _)
-            w/ AddressSize <- (Head(qrams))::AddressSize
-            w/ DataSize <- Length(qrams);
+            w/ AddressSize <- addressSize
+            w/ DataSize <- valueSize;
+    }
+    
+    internal function SingleImplicitQRAMOracle(DataValue : (Bool[],Bool[])) : SingleBitQRAM {
+        let (address,value) = DataValue;
+        return Default<SingleBitQRAM>()
+            w/ Lookup <- ApplySingleImplicitQRAMOracleValues(address, value, _, _);
+    }
+
+    internal operation ApplySingleImplicitQRAMOracleValues(
+        Adress: Bool[], 
+        Values: Bool[],
+        AddressRegister : Qubit[],
+        Target : Qubit[]
+    )
+    : Unit is Adj + Ctl {
+        for((idx,value) in Enumerated(Values)){
+            if(value)
+            {
+                 (ControlledOnBitString(Adress, X))(AddressRegister, Target[idx]);
+            }
+        }
     }
 
     internal operation ApplyImplicitQRAMOracle(
@@ -37,44 +67,10 @@
         TargetRegister : Qubit[]
     )
     : Unit is Adj + Ctl {
-        for ((qram, target) in Zip(Qrams, TargetRegister)) {
-            qram::Lookup(AddressRegister, target) ;
-        }
-            
-    }
-
-    internal function SingleImplicitQRAMOracle(OnesAddresses : Bool[][]) : SingleBitQRAM {
-        let addressLength = Length(Head(OnesAddresses));
-        //return QRAM(ApplySingleImplicitQRAMOracle(OnesAddresses, _, _),addressLength);
-        return Default<SingleBitQRAM>()
-            w/ Lookup <- ApplySingleImplicitQRAMOracle(OnesAddresses, _, _)
-            w/ AddressSize <- addressLength;
-    }
-
-    internal operation ApplySingleImplicitQRAMOracle(
-        OnesAddresses: Bool[][], 
-        AddressRegister : Qubit[],
-        Target : Qubit
-    )
-    : Unit is Adj + Ctl {
-        for (address in OnesAddresses) {
-            (ControlledOnBitString(address, X))(AddressRegister, Target); 
+        for (qram in Qrams) {
+            qram::Lookup(AddressRegister, TargetRegister) ;
         }
     }
-
-    // [5,0,2,8,7]
-    // [[true, false, true], []]
-    // Assume that if data is not power of 2, assume rest 0s
-    internal function OnesAddressesFromData(dataArray : Bool[][]) : Bool[][][] {
-        let numDataBits = Length(Head(dataArray));
-        mutable onesAddresses = new Bool[][][numDataBits];
-        
-        for (idx in 0..numDataBits-1) {
-            set onesAddresses w/=idx <- OnesAddressesFromDataValue(ElementsAt(dataArray, idx));
-        }
-        return onesAddresses;
-    }
-
 
 ///////////////////////////////////////////////////////////////////////////
 // UTILITY FUNCTIONS

--- a/tests/QRamTest.qs
+++ b/tests/QRamTest.qs
@@ -1,4 +1,4 @@
-﻿namespace tests {
+﻿namespace Qram.Tests {
     
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Convert;
@@ -12,50 +12,52 @@
 
     @Test("QuantumSimulator")
     operation RetrieveImplicitQramEvenMatchResultsTrue() : Unit {
-        let five = [true,false,true];
-        let seven = [true,true,true]; 
-        let data = [seven,five];
+        let five = IntAsBoolArray(5,3);
+        let fiveHasThree = (five,IntAsBoolArray(3,2));
+        let sevenHasOne = (IntAsBoolArray(7,3),IntAsBoolArray(1,2));
+        let data = [fiveHasThree,sevenHasOne];
         let queryAddress = five;        
         let result = CreateQueryAndMeasureQRAM(data, queryAddress);
-        EqualityFactI(result, 1, "Expecting True when matched"); 
+        EqualityFactI(result, 3, "Expecting item number 5, which is 3 when matched"); 
         Message("Test passed.");
     }
 
     @Test("QuantumSimulator")
     operation RetrieveImplicitQramUnEvenMatchResultsTrue() : Unit {
-        let three = [false,true,false];
-        let five = [true,false,true];
-        let seven = [true,true,true]; 
-        let data = [seven,five, three];
+        let five = IntAsBoolArray(5,3);
+        let fiveHasThree = (five,IntAsBoolArray(3,2));
+        let sevenHasOne = ([true,true,true], [false,true]); 
+        let data = [fiveHasThree,sevenHasOne];
         let queryAddress = five;
         let result = CreateQueryAndMeasureQRAM(data, queryAddress);
-        EqualityFactI(result, 1, "Expecting True when matched"); 
+        EqualityFactI(result, 3, "Expecting 3 when matched"); 
         Message("Test passed.");
     }
 
     @Test("QuantumSimulator")
     operation RetrieveImplicitQramMismatchResultsFalse() : Unit {
-        let two = [false,true,false];
-        let five = [true,false,true];
-        let seven = [true,true,true]; 
-        let data = [seven,five];
+        let fiveHasThree = (IntAsBoolArray(5,3),IntAsBoolArray(3,2));
+        let sevenHasOne = (IntAsBoolArray(7,3),IntAsBoolArray(1,2));
+        let data = [fiveHasThree,sevenHasOne];
+        let two = IntAsBoolArray(2,3);
         let queryAddress = two;
         let result = CreateQueryAndMeasureQRAM(data, queryAddress);
         EqualityFactI(result, 0, "Expecting False when no match"); 
         Message("Test passed.");
     }
 
-    @Test("QuantumSimulator")
-    operation RetrieveImplicitQramEmptyResultFalse() : Unit {
-        let two = [false,true,false];
-        let data = new Bool[][0];
-        let queryAddress = two;
+   @Test("QuantumSimulator")
+    operation RetrieveImplicitQramResultsEndianPreservance() : Unit {
+        let four = IntAsBoolArray(4,3);
+        let fourHasThree = (four,IntAsBoolArray(1,2));
+        let data = [fourHasThree];
+        let queryAddress = four;
         let result = CreateQueryAndMeasureQRAM(data, queryAddress);
-        EqualityFactI(result, 0, "Expecting False when no match in empty Qram"); 
+        EqualityFactI(result, 1, "Expecting 1 when matched. If you see 0 Enidan error is in the address or 2 that means Endian broke in the value"); 
         Message("Test passed.");
     }
 
-    internal operation CreateQueryAndMeasureQRAM(data: Bool[][], queryAddress : Bool[]) : Int {
+    internal operation CreateQueryAndMeasureQRAM(data: (Bool[],Bool[])[], queryAddress : Bool[]) : Int {
         let memory = ImplicitQRAMOracle(data);
         using((addressRegister, targetRegister) = (Qubit[memory::AddressSize], Qubit[memory::DataSize])){
             ApplyPauliFromBitString (PauliX, true, queryAddress, addressRegister);
@@ -64,6 +66,4 @@
             return MeasureInteger(LittleEndian(targetRegister));
         }
     }
-
-
 }


### PR DESCRIPTION
Was debugging a bit, because I thought it was a small issue, but seems the amount of output bits was set to the address length and al output bits were set, which resulted in all kinds of situations. So rewrote the api to support different address lengths from the output sizes, taking the bit array size as the value size.